### PR TITLE
Add exception when Mixture is given empty tasks

### DIFF
--- a/seqio/dataset_providers.py
+++ b/seqio/dataset_providers.py
@@ -1183,6 +1183,8 @@ class Mixture(DatasetProviderBase):
       sample_fn: SampleFn callable that implements sampling logic to interleave
         multiple datasets into a single dataset.
     """
+    if not tasks:
+      raise ValueError("tasks must not be empty when creating a mixture.")
     self._task_to_rate = {}
     self._tasks = []
     self._sub_mixtures = []


### PR DESCRIPTION
Currently, the code
```
seqio.MixtureRegistry.add(
    "asdf",
    [],
    default_rate=10,
)
```
gives the exception `ValueError: All Tasks in a Mixture must have the same output features.` which is pretty uninformative, given that the issue is actually that `tasks` is empty. This adds an explicit exception for this case. I forget if Google prefers `if not list` or `if len(list) == 0`, but I'm using the former since it's preferred by PEP-8 (https://www.python.org/dev/peps/pep-0008/#programming-recommendations).