### PR TITLE
Fix name for usage example in cache_tasks_main.py

### DIFF
--- a/seqio/scripts/cache_tasks_main.py
+++ b/seqio/scripts/cache_tasks_main.py
@@ -17,7 +17,7 @@ r"""Dumps preprocessed tasks as TFRecord of tf.Examples.
 
 Usage:
 ====================
-cache_tasks_main \
+seqio_cache_tasks \
 --tasks=my_task_*,your_task \
 --excluded_tasks=my_task_5 \
 --output_cache_dir=/path/to/cache_dir \


### PR DESCRIPTION
The script gets installed as seqio_cache_tasks on my system.