### PR TITLE
Accept str argument in add_global_cache_dirs

### DIFF
--- a/seqio/utils.py
+++ b/seqio/utils.py
@@ -24,6 +24,7 @@ from absl import logging
 import numpy as np
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets as tfds
+from typing import Sequence
 
 _INFO_FILENAME = "info.{split}.json"
 _STATS_FILENAME = "stats.{split}.json"


### PR DESCRIPTION
Currently, if you pass a string to `add_global_cache_dirs`, each character of the string gets added to the list of global cache directories because of the use of the `+=` operator. Since the function is not documented, it's easy to make this mistake (I have done it at least once, and @dptam just ran into it last night) This PR converts string arguments to singleton lists, which circumvents this issue.