### PR TITLE
ByteVocabulary produces incorrect results for multi-byte characters

### DIFF
--- a/seqio/vocabularies.py
+++ b/seqio/vocabularies.py
@@ -466,6 +466,8 @@ class ByteVocabulary(Vocabulary):
       extra_ids: an optional integer
     """
     self._byte_size = 256
+    self._byte_strings = tf.constant([
+      bytes([i]) for i in range(self._byte_size)])
     # The special tokens: 0=PAD, 1=EOS,and 2=UNK
     self._num_special_tokens = 3
     super().__init__(extra_ids=extra_ids)
@@ -577,7 +579,15 @@ class ByteVocabulary(Vocabulary):
             tf.math.greater_equal(ids, lower_bound),
             tf.math.less(ids, upper_bound)))
     ids = ids - self._num_special_tokens
-    return tf.strings.unicode_encode(ids, "UTF-8", errors="ignore")
+    string = tf.strings.reduce_join(
+      tf.gather(self._byte_strings, ids), axis=-1)
+
+    # Drop invalid byte sequences.
+    return tf.strings.unicode_transcode(
+      input=string,
+      input_encoding="UTF-8",
+      output_encoding="UTF-8",
+      errors="ignore")
 
   def __eq__(self, other):
     if not isinstance(other, ByteVocabulary):

--- a/seqio/vocabularies_test.py
+++ b/seqio/vocabularies_test.py
@@ -331,9 +331,10 @@ class SentencepieceVocabularyTest(absltest.TestCase):
 
 class ByteVocabularyTest(absltest.TestCase):
 
-  TEST_STRING = "this is a test"
+  TEST_STRING = "this is a test 🤗 你好"
   TEST_BYTE_IDS = (
-      119, 107, 108, 118, 35, 108, 118, 35, 100, 35, 119, 104, 118, 119)
+      119, 107, 108, 118, 35, 108, 118, 35, 100, 35, 119, 104, 118, 119, 35,
+      243, 162, 167, 154, 35, 231, 192, 163, 232, 168, 192)
 
   def test_decode_tf(self):
     vocab = vocabularies.ByteVocabulary()
@@ -360,6 +361,15 @@ class ByteVocabularyTest(absltest.TestCase):
 
     # Add two ids that are outside the allowed interval. They should be ignored.
     ids = tuple(list(self.TEST_BYTE_IDS) + [3000, -4000])
+    expected_str = self.TEST_STRING
+
+    self.assertEqual(expected_str, _decode_tf(vocab, ids))
+
+  def test_decode_tf_invalid_byte_sequence(self):
+    vocab = vocabularies.ByteVocabulary()
+
+    # Add an invalid byte sequence, which should be ignored.
+    ids = tuple(list(self.TEST_BYTE_IDS) + [0xc0, 0xc1])
     expected_str = self.TEST_STRING
 
     self.assertEqual(expected_str, _decode_tf(vocab, ids))


### PR DESCRIPTION
When using the `decode_tf` function from `ByteVocabulary`, characters outside of the ASCII range are decoded incorrectly. Please consider the minimal reproducible example below.

```python
from seqio import ByteVocabulary

byte_vocabulary = ByteVocabulary()

example_text = "Hello 🤗 你好"

encoded = byte_vocabulary.encode(example_text)
decoded = byte_vocabulary.decode(encoded)
print(decoded)
# Hello 🤗 你好

encoded_tf = byte_vocabulary.encode_tf(example_text)
decoded_tf = byte_vocabulary.decode_tf(encoded_tf)
print(decoded_tf.numpy().decode("utf-8"))
# Hello ð ä½ å¥½
```

This behaviour was introduced in commit d00cc4c790e2c4aee5907ecf265220f39691af20. Token `ids` are passed to [`tf.strings.unicode_encode`](https://www.tensorflow.org/api_docs/python/tf/strings/unicode_encode), which requires Unicode code points as input, rather than UTF-8 bytes. This works for characters in the ASCII range, where the byte values are equivalent to the code points.

This pull request modifies the `decode_tf` function to support multi-byte characters. To avoid regressions, the ByteVocabulary `TEST_STRING` has been updated to include text outside of the ASCII range. Additionally, a new test has been added to validate that invalid byte sequences are ignored.