### PR TITLE
Patch Mixture.num_input_examples to only use split if it exists

### DIFF
--- a/seqio/dataset_providers.py
+++ b/seqio/dataset_providers.py
@@ -1626,7 +1626,7 @@ class Mixture(DatasetProviderBase):
     return float(rate)
 
   def num_input_examples(self, split: str) -> int:
-    return sum(t.num_input_examples(split) for t in self.tasks)
+    return sum(t.num_input_examples(split) for t in self.tasks if split in t.splits)
 
   @property
   def splits(self) -> Sequence[str]:


### PR DESCRIPTION
If a mixture has tasks with different sets of splits e.g. `task1.split = ("train", "test")` and `task2.split = ("train",)`, `mix.num_input_examples('test')` will fail unless this patch is applied.