### PR TITLE
Use tensorflow-text from GitHub repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         'packaging',
         'pyglove',
         'sentencepiece >= 0.2',
-        'tensorflow-text',
+        'tensorflow-text @ git+https://github.com/tensorflow/text#subdirectory=oss_scripts/pip_package',
         # Ping to a specific version to avoid endless backtracking during
         # pip dependency resolution.
         'tfds-nightly==4.9.2.dev202308090034',


### PR DESCRIPTION
Uses tensorflow-text dependency from the GitHub repository

Fixes broken installation on Windows and other systems where there are no supported PyPi releases for tensorflow-text